### PR TITLE
Update to Confluent.Kafka 1.0.0-RC2

### DIFF
--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta3" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC7" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-beta3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
+    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleConsumer/LocalSchemaRegistry.cs
+++ b/samples/dotnet/ConsoleConsumer/LocalSchemaRegistry.cs
@@ -64,6 +64,11 @@ namespace ConsoleConsumer
             throw new System.NotImplementedException();
         }
 
+        public Task<List<int>> GetSubjectVersionsAsync(string subject)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public Task<bool> IsCompatibleAsync(string subject, string schema)
         {
             throw new System.NotImplementedException();

--- a/samples/dotnet/ConsoleConsumer/MagicAvroDeserializer.cs
+++ b/samples/dotnet/ConsoleConsumer/MagicAvroDeserializer.cs
@@ -16,7 +16,8 @@ namespace ConsoleConsumer
         {
             this.impl = impl;
         }
-        public Task<TValue> DeserializeAsync(ReadOnlyMemory<byte> data, bool isNull, bool isKey, MessageMetadata messageMetadata, TopicPartition source)
+
+        public Task<TValue> DeserializeAsync(ReadOnlyMemory<byte> data, bool isNull, SerializationContext context)
         {
             // TODO: find a better way to solve this
             // Allocating memory in a critical path of the trigger
@@ -26,7 +27,7 @@ namespace ConsoleConsumer
             var dataSpan = data.Span;
             dataSpan.TryCopyTo(data2Span.Slice(Prefix));
 
-            return this.impl.DeserializeAsync(data2, isNull, isKey, messageMetadata, source);
+            return this.impl.DeserializeAsync(data2, isNull, context);
         }
     }
 }

--- a/samples/dotnet/ConsoleConsumer/Program.cs
+++ b/samples/dotnet/ConsoleConsumer/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -59,26 +60,24 @@ namespace ConsoleConsumer
 
         }
 
+        static void LogAssignedPartitions<TKey, TValue>(IConsumer<TKey, TValue> consumer, List<TopicPartition> e)
+        {
+            Console.WriteLine($"Assigned partitions: [{string.Join(", ", e)}]");
+        }
+
+        static void LogRekovedPartitions<TKey, TValue>(IConsumer<TKey, TValue> consumer, List<TopicPartitionOffset> e)
+        {
+            Console.WriteLine($"Revoked partitions: [{string.Join(", ", e.Select(x => x.TopicPartition))}]");
+        }
+
         private static void StartPageViewRegionConsumer(ConsumerConfig conf, CancellationToken cts = default)
         {
             var builder = new ConsumerBuilder<Ignore, PageViewRegion>(conf)
                 .SetErrorHandler((_, e) => {
                     Console.WriteLine(e.Reason);
                 })
-                .SetRebalanceHandler((_, e) =>
-                {
-                    if (e.IsAssignment)
-                    {
-                        Console.WriteLine($"Assigned partitions: [{string.Join(", ", e.Partitions)}]");
-                        // possibly override the default partition assignment behavior:
-                        // consumer.Assign(...) 
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Revoked partitions: [{string.Join(", ", e.Partitions)}]");
-                        // consumer.Unassign()
-                    }
-                });
+                .SetPartitionsAssignedHandler(LogAssignedPartitions)
+                .SetPartitionsRevokedHandler(LogRekovedPartitions);
 
             var avroSchema = PageViewRegion._SCHEMA;
             var schemaRegistry = new LocalSchemaRegistry(avroSchema.ToString());
@@ -150,20 +149,8 @@ namespace ConsoleConsumer
                 .SetErrorHandler((_, e) => {
                     Console.WriteLine(e.Reason);
                 })
-                .SetRebalanceHandler((_, e) =>
-                {
-                    if (e.IsAssignment)
-                    {
-                        Console.WriteLine($"Assigned partitions: [{string.Join(", ", e.Partitions)}]");
-                        // possibly override the default partition assignment behavior:
-                        // consumer.Assign(...) 
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Revoked partitions: [{string.Join(", ", e.Partitions)}]");
-                        // consumer.Unassign()
-                    }
-                });
+                .SetPartitionsAssignedHandler(LogAssignedPartitions)
+                .SetPartitionsRevokedHandler(LogRekovedPartitions);
 
             var avroSchema = PageViews._SCHEMA;
             var schemaRegistry = new LocalSchemaRegistry(avroSchema.ToString());
@@ -235,20 +222,8 @@ namespace ConsoleConsumer
                 .SetErrorHandler((_, e) => {
                     Console.WriteLine(e.Reason);
                 })
-                .SetRebalanceHandler((_, e) =>
-                {
-                    if (e.IsAssignment)
-                    {
-                        Console.WriteLine($"Assigned partitions: [{string.Join(", ", e.Partitions)}]");
-                        // possibly override the default partition assignment behavior:
-                        // consumer.Assign(...) 
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Revoked partitions: [{string.Join(", ", e.Partitions)}]");
-                        // consumer.Unassign()
-                    }
-                });
+                .SetPartitionsAssignedHandler(LogAssignedPartitions)
+                .SetPartitionsRevokedHandler(LogRekovedPartitions);
 
             var avroSchema = PageViews._SCHEMA;
             var schemaRegistry = new LocalSchemaRegistry(avroSchema.ToString());
@@ -321,20 +296,8 @@ namespace ConsoleConsumer
                 .SetErrorHandler((_, e) => {
                     Console.WriteLine(e.Reason);
                 })
-                .SetRebalanceHandler((_, e) =>
-                {
-                    if (e.IsAssignment)
-                    {
-                        Console.WriteLine($"Assigned partitions: [{string.Join(", ", e.Partitions)}]");
-                        // possibly override the default partition assignment behavior:
-                        // consumer.Assign(...) 
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Revoked partitions: [{string.Join(", ", e.Partitions)}]");
-                        // consumer.Unassign()
-                    }
-                });
+                .SetPartitionsAssignedHandler(LogAssignedPartitions)
+                .SetPartitionsRevokedHandler(LogRekovedPartitions);
 
             var avroSchema = PageViews._SCHEMA;
             var schemaRegistry = new LocalSchemaRegistry(avroSchema.ToString());

--- a/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
+++ b/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta3" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC8-test-deps9" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-beta3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
+    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>
    <ItemGroup>

--- a/samples/dotnet/ConsoleProducer/ProtoBufSerializer.cs
+++ b/samples/dotnet/ConsoleProducer/ProtoBufSerializer.cs
@@ -8,7 +8,7 @@ namespace ConsoleProducer
     /// </summary>
     public class ProtobufSerializer<T> : ISerializer<T> where T : IMessage<T>, new()
     {
-        public byte[] Serialize(T data, bool isKey, MessageMetadata messageMetadata, TopicPartition destination)
+        public byte[] Serialize(T data, SerializationContext context)
             => data.ToByteArray();
     }
 }

--- a/samples/dotnet/KafkaFunctionSample/.vscode/settings.json
+++ b/samples/dotnet/KafkaFunctionSample/.vscode/settings.json
@@ -2,7 +2,7 @@
   "azureFunctions.projectRuntime": "~2",
   "azureFunctions.projectLanguage": "C#",
   "azureFunctions.templateFilter": "Verified",
-  "azureFunctions.deploySubpath": "bin/Release/netcoreapp2.2/publish",
+  "azureFunctions.deploySubpath": "bin/Release/netcoreapp2.1/publish",
   "azureFunctions.preDeployTask": "publish",
   "debug.internalConsoleOptions": "neverOpen"
 }

--- a/samples/dotnet/KafkaFunctionSample/.vscode/tasks.json
+++ b/samples/dotnet/KafkaFunctionSample/.vscode/tasks.json
@@ -35,7 +35,7 @@
       "type": "func",
       "dependsOn": "build",
       "options": {
-        "cwd": "${workspaceFolder}/bin/Debug/netcoreapp2.2"
+        "cwd": "${workspaceFolder}/bin/Debug/netcoreapp2.1"
       },
       "command": "host start",
       "isBackground": true,

--- a/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
+++ b/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta3" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC8-test-deps9" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-beta3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
+    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/FunctionExecutorBase.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/FunctionExecutorBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             try
             {
-                this.consumer.Commit(topicPartitionOffsets, this.cancellationTokenSource.Token);
+                this.consumer.Commit(topicPartitionOffsets);
 
                 if (this.logger.IsEnabled(LogLevel.Information))
                 {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/LocalSchemaRegistry.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/LocalSchemaRegistry.cs
@@ -66,6 +66,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             throw new System.NotImplementedException();
         }
 
+        public Task<List<int>> GetSubjectVersionsAsync(string subject)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public Task<bool> IsCompatibleAsync(string subject, string schema)
         {
             throw new System.NotImplementedException();

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -20,10 +20,10 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta3" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC7" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
+    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-beta3" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/ProtobufDeserializer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/ProtobufDeserializer.cs
@@ -19,7 +19,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             parser = new MessageParser<T>(() => new T());
         }
 
-        public T Deserialize(ReadOnlySpan<byte> data, bool isNull, bool isKey, MessageMetadata messageMetadata, TopicPartition source)
-            => parser.ParseFrom(data.ToArray());
+        public T Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context) => parser.ParseFrom(data.ToArray());
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
@@ -19,9 +19,9 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta3" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0-RC8-test-deps9" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-beta3" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
+    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
   </ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
@@ -22,10 +22,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
         public void SetConsumer(IConsumer<TKey, TValue> consumer) => this.consumer = consumer;
 
-        protected override IConsumer<TKey, TValue> CreateConsumer(ConsumerConfig config, Action<Consumer<TKey, TValue>, Error> errorHandler, Action<IConsumer<TKey, TValue>, RebalanceEvent> rebalanceHandler, IAsyncDeserializer<TValue> asyncValueDeserializer = null, IDeserializer<TValue> valueDeserializer = null, IAsyncDeserializer<TKey> keyDeserializer = null)
+        protected override IConsumer<TKey, TValue> CreateConsumer(ConsumerConfig config, Action<Consumer<TKey, TValue>, Error> errorHandler, Action<IConsumer<TKey, TValue>, System.Collections.Generic.List<TopicPartition>> partitionsAssignedHandler, Action<IConsumer<TKey, TValue>, System.Collections.Generic.List<TopicPartitionOffset>> partitionsRevokedHandler, IAsyncDeserializer<TValue> asyncValueDeserializer = null, IDeserializer<TValue> valueDeserializer = null, IAsyncDeserializer<TKey> keyDeserializer = null)
         {
             return this.consumer ??
-                base.CreateConsumer(config, errorHandler, rebalanceHandler, asyncValueDeserializer, valueDeserializer, keyDeserializer);
+                base.CreateConsumer(config, errorHandler, partitionsAssignedHandler, partitionsRevokedHandler, asyncValueDeserializer, valueDeserializer, keyDeserializer);
         }
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
@@ -168,8 +168,8 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
 
             var committed = new ConcurrentQueue<TopicPartitionOffset>();
 
-            consumer.Setup(x => x.Commit(It.IsAny<IEnumerable<TopicPartitionOffset>>(), It.IsAny<CancellationToken>()))
-                .Callback<IEnumerable<TopicPartitionOffset>, CancellationToken>((topicPartitionOffsetCollection, _) =>
+            consumer.Setup(x => x.Commit(It.IsAny<IEnumerable<TopicPartitionOffset>>()))
+                .Callback<IEnumerable<TopicPartitionOffset>>((topicPartitionOffsetCollection) =>
                 {
                     foreach (var item in topicPartitionOffsetCollection)
                     {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests</RootNamespace>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
- Use Confluent.Kafka 1.0.0-RC2 from 1.0.0-beta3 (as recommended on their repo)
- Target .NET Core 2.1 instead of .NET 2.2


Fixes #33 