### PR TITLE
Producer sends messages in batches

### DIFF
--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
   </ItemGroup>
    <ItemGroup>

--- a/samples/dotnet/KafkaFunctionSample/AvroGenericTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/AvroGenericTriggers.cs
@@ -42,12 +42,15 @@ namespace KafkaFunctionSample
 
         [FunctionName(nameof(PageViews))]
         public static void PageViews(
-           [KafkaTrigger("LocalBroker", "pageviews", AvroSchema = PageViewsSchema, ConsumerGroup = "azfunc")] KafkaEventData kafkaEvent,
+           [KafkaTrigger("LocalBroker", "pageviews", AvroSchema = PageViewsSchema, ConsumerGroup = "azfunc")] KafkaEventData[] kafkaEvents,
            ILogger logger)
         {
-            if (kafkaEvent.Value is GenericRecord genericRecord)
+            foreach (var kafkaEvent in kafkaEvents)
             {
-                logger.LogInformation($"{GenericToJson(genericRecord)}");
+                if (kafkaEvent.Value is GenericRecord genericRecord)
+                {
+                    logger.LogInformation($"{GenericToJson(genericRecord)}");
+                }
             }
         }
 

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
@@ -35,12 +34,5 @@
     <None Update="cacert.pem">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Config\" />
-    <Folder Include="Listeners\" />
-    <Folder Include="Properties\" />
-    <Folder Include="Trigger\" />
-    <Folder Include="Serialization\" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/IKafkaProducer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/IKafkaProducer.cs
@@ -8,6 +8,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
     public interface IKafkaProducer
     {
-        Task ProduceAsync(string topic, KafkaEventData item, CancellationToken cancellationToken);
+        /// <summary>
+        /// Produces a Kafka message
+        /// The message is only sent once <see cref="Flush"/> is called
+        /// </summary>
+        void Produce(string topic, KafkaEventData item);
+
+        /// <summary>
+        /// Flushes the pending items to Kafka
+        /// </summary>
+        void Flush(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAsyncCollector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,13 +18,23 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.producer = producer;
         }
 
-        public async Task AddAsync(KafkaEventData item, CancellationToken cancellationToken = default)
+        public Task AddAsync(KafkaEventData item, CancellationToken cancellationToken = default)
         {
-            await this.producer.ProduceAsync(this.topic, item, cancellationToken);
+            this.producer.Produce(this.topic, item);
+            return Task.CompletedTask;
         }
 
         public Task FlushAsync(CancellationToken cancellationToken = default)
         {
+            try
+            {
+                this.producer.Flush(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // cancellationToken was cancelled
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -331,15 +331,21 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 var logs = new List<string>(host1Log.GetAllLogMessages().Where(messageFilter).Select(x => x.FormattedMessage));
                 logs.AddRange(host2Log.GetAllLogMessages().Where(messageFilter).Select(x => x.FormattedMessage));
 
+                var multipleProcessItemCount = 0;
                 for (int i = 1; i <= producedMessagesCount; i++)
                 {
                     var currentMessage = EndToEndTestExtensions.CreateMessageValue(messagePrefix, i);
                     var count = logs.Count(x => x == currentMessage);
                     if (count > 1)
                     {
+                        Assert.True(count < 3, "No item should be processed more than twice");
+                        multipleProcessItemCount++;
                         Console.WriteLine($"{currentMessage} was processed {count} times");
                     }
                 }
+
+                // Should not process more than 10% of all items a second time.
+                Assert.InRange(multipleProcessItemCount, 0, producedMessagesCount / 10);
 
             }
             finally

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="librdkafka.redist" Version="1.0.0" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />


### PR DESCRIPTION
Changes:

* Producer sends messages in batches. Initial version had a call for each produced message. Now messages are sent in batches.
* Removed direct dependency to librdkafka.redist
* Change all sample function code to consume events in batches

Part of #11 