### PR TITLE
Remove KafkaEventData(byte[]) ctor

### DIFF
--- a/samples/dotnet/KafkaFunctionSample/AvroSpecificTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/AvroSpecificTriggers.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Microsoft.Azure.WebJobs.Extensions.Kafka;
+using Confluent.SchemaRegistry.Serdes;
 
 namespace KafkaFunctionSample
 {
@@ -25,6 +26,39 @@ namespace KafkaFunctionSample
             foreach (var kafkaEvent in kafkaEvents)
             {
                 logger.LogInformation($"{JsonConvert.SerializeObject(kafkaEvent.Value)}");
+            }
+        }
+
+
+        [FunctionName(nameof(UserAsString))]
+        public static void UserAsString(
+           [KafkaTrigger("LocalBroker", "users", ValueType = typeof(UserRecord), ConsumerGroup = "azfunc_asstring")] string[] eventsAsString,
+           ILogger logger)
+        {
+            foreach (var eventString in eventsAsString)
+            {
+                logger.LogInformation($"Users from string: {eventString}");
+            }
+        }
+
+        static AvroDeserializer<UserRecord> myCustomDeserialiser = new AvroDeserializer<UserRecord>(new LocalSchemaRegistry(UserRecord.SchemaText));
+
+        /// <summary>
+        /// This function shows how to implement a custom deserialiser in the function method
+        /// </summary>
+        /// <returns>The as bytes.</returns>
+        /// <param name="kafkaEvents">Kafka events.</param>
+        /// <param name="logger">Logger.</param>
+        [FunctionName(nameof(UserAsBytes))]
+        public static async Task UserAsBytes(
+           [KafkaTrigger("LocalBroker", "users", ValueType = typeof(byte[]), ConsumerGroup = "azfunc_bytes")] KafkaEventData[] kafkaEvents,
+           ILogger logger)
+        {
+            foreach (var kafkaEvent in kafkaEvents)
+            {
+                var desUserRecord = await myCustomDeserialiser.DeserializeAsync(((byte[])kafkaEvent.Value), false, Confluent.Kafka.SerializationContext.Empty);
+
+                logger.LogInformation($"Custom deserialised user: {JsonConvert.SerializeObject(desUserRecord)}");
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Config/KafkaExtensionConfigProvider.cs
@@ -52,12 +52,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             this.configuration.ConfigurationSection.Bind(this.options);
 
             context
-               .AddConverter<string, KafkaEventData>(ConvertString2KafkaEventData)
                .AddConverter<KafkaEventData, string>(ConvertKafkaEventData2String)
                .AddConverter<KafkaEventData, ISpecificRecord>(ConvertKafkaEventData2AvroSpecific)
-               .AddConverter<byte[], KafkaEventData>(ConvertBytes2KafkaEventData)
-               .AddConverter<KafkaEventData, byte[]>(ConvertKafkaEventData2Bytes)
-               .AddOpenConverter<OpenType.Poco, KafkaEventData>(ConvertPocoToKafkaEventData);
+               .AddConverter<KafkaEventData, byte[]>(ConvertKafkaEventData2Bytes);
 
             // register our trigger binding provider
             var triggerBindingProvider = new KafkaTriggerAttributeBindingProvider(this.config, this.options, this.converterManager, this.nameResolver, this.loggerFactory);
@@ -114,18 +111,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             return JsonConvert.SerializeObject(props);
         }
 
-        private static KafkaEventData ConvertBytes2KafkaEventData(byte[] input)
-            => new KafkaEventData(input);
-
         private static byte[] ConvertKafkaEventData2Bytes(KafkaEventData input)
-            => Encoding.UTF8.GetBytes(input.Value.ToString());
-
-        private static KafkaEventData ConvertString2KafkaEventData(string input)
-            => ConvertBytes2KafkaEventData(Encoding.UTF8.GetBytes(input));
-
-        private static Task<object> ConvertPocoToKafkaEventData(object arg, Attribute attrResolved, ValueBindingContext context)
         {
-            return Task.FromResult<object>(ConvertString2KafkaEventData(JsonConvert.SerializeObject(arg)));
+            if (input.Value is byte[] bytes)
+            {
+                return bytes;
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/KafkaEventData.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/KafkaEventData.cs
@@ -19,10 +19,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
         }
 
-        public KafkaEventData(byte[] bytes)
-        {
-        }
-
         public KafkaEventData(IConsumeResultData msg)
         {
             this.Key = msg.Key;

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerBindingStrategy.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Trigger/KafkaTriggerBindingStrategy.cs
@@ -11,14 +11,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 {
     public class KafkaTriggerBindingStrategy : ITriggerBindingStrategy<KafkaEventData, KafkaTriggerInput>
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
+        /// <summary>
+        /// Given a raw string, convert to a TTriggerValue.
+        /// This is primarily used in the "invoke from dashboard" path. 
+        /// </summary>
         public KafkaTriggerInput ConvertFromString(string input)
         {
-            byte[] bytes = Encoding.UTF8.GetBytes(input);
-            var eventData = new KafkaEventData(bytes);
-
-            // Return a single event. Doesn't support multiple dispatch 
-            return KafkaTriggerInput.New(eventData);
+            // Need to dig up to see how "invoke from dashboard" works.
+            // Returning null for now, since it is not being called
+            return null;
         }
 
         // Single instance: Core --> EventData
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
             return value.GetSingleEventData();
         }
@@ -35,7 +36,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
             return value.Events;
         }
@@ -65,7 +66,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             if (value == null)
             {
-                throw new ArgumentNullException("value");
+                throw new ArgumentNullException(nameof(value));
             }
 
             var bindingData = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
Changes

* Remove KafkaEventData(byte[]) ctor
* Add custom deserialisation example to sample function project
* Add binding to string in sample function project

Fixes #43 
Addresses `string` binding from #44 