### PR TITLE
Reworking Listener creating in to a Factory pattern. 

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerAvro.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerAvro.cs
@@ -1,0 +1,44 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.SchemaRegistry.Serdes;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    /// <summary>
+    /// Kafka listener.
+    /// Connects a Kafka trigger function with a Kafka Consumer
+    /// </summary>
+    internal class KafkaListenerAvro<TKey, TValue> : KafkaListener<TKey, TValue>
+    {
+        private readonly string avroSchema;
+
+        public KafkaListenerAvro(
+            ITriggeredFunctionExecutor executor,
+            bool singleDispatch,
+            KafkaOptions options,
+            string brokerList,
+            string topic,
+            string consumerGroup,
+            string eventHubConnectionString,
+            string avroSchema,
+            ILogger logger) : base(executor, singleDispatch, options, brokerList, topic, consumerGroup, eventHubConnectionString, logger)
+        {
+            this.avroSchema = avroSchema;
+        }
+
+        public override Task StartAsync(CancellationToken cancellationToken)
+        {
+            var schemaRegistry = new LocalSchemaRegistry(avroSchema);
+            AvroDeserializer<TValue> avroDeserializer = new AvroDeserializer<TValue>(schemaRegistry);
+            SetConsumerAndExecutor(avroDeserializer, null, null);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerFactory.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerFactory.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Avro.Specific;
+using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Azure.WebJobs.Host.Listeners;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.Listeners
+{
+    internal static class KafkaListenerFactory
+    {
+        public static IListener CreateFor(KafkaTriggerAttribute attribute,
+            ITriggeredFunctionExecutor executor,
+            bool singleDispatch,
+            KafkaOptions options,
+            string brokerList,
+            string topic,
+            string consumerGroup,
+            string eventHubConnectionString,
+            ILogger logger)
+        {
+            var valueType = GetValueType(attribute, out string avroSchema);
+            return (IListener)typeof(KafkaListenerFactory)
+                .GetMethod(nameof(CreateFor), BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.InvokeMethod)
+                .MakeGenericMethod(attribute.KeyType ?? typeof(Ignore), valueType)
+                .Invoke(null, new object[]
+                {
+                    executor,
+                    singleDispatch,
+                    options,
+                    brokerList,
+                    topic,
+                    consumerGroup,
+                    eventHubConnectionString,
+                    logger, avroSchema
+                });
+        }
+
+        private static Type GetValueType(KafkaTriggerAttribute attribute, out string avroSchema)
+        {
+            avroSchema = null;
+
+            var valueType = attribute.ValueType;
+            if (valueType == null)
+            {
+                if (!string.IsNullOrEmpty(attribute.AvroSchema))
+                {
+                    avroSchema = attribute.AvroSchema;
+                    return typeof(Avro.Generic.GenericRecord);
+                }
+                else
+                {
+                    return typeof(string);
+                }
+            }
+            else
+            {
+                if (typeof(ISpecificRecord).IsAssignableFrom(valueType))
+                {
+                    var specificRecord = (ISpecificRecord)Activator.CreateInstance(valueType);
+                    avroSchema = specificRecord.Schema.ToString();
+                }
+            }
+
+            return valueType;
+        }
+
+        private static KafkaListener<TKey, TValue> CreateFor<TKey, TValue>(
+            ITriggeredFunctionExecutor executor,
+            bool singleDispatch,
+            KafkaOptions options,
+            string brokerList,
+            string topic,
+            string consumerGroup,
+            string eventHubConnectionString,
+            ILogger logger,
+            string avroSchema = null)
+        {
+            if (typeof(ISpecificRecord).IsAssignableFrom(typeof(TValue)))
+            {
+                if (string.IsNullOrWhiteSpace(avroSchema))
+                {
+                    throw new ArgumentNullException(nameof(avroSchema), $@"parameter is required when creating an Avro-based Listener");
+                }
+
+                return new KafkaListenerAvro<TKey, TValue>(executor,
+                    singleDispatch,
+                    options,
+                    brokerList,
+                    topic,
+                    consumerGroup,
+                    eventHubConnectionString,
+                    avroSchema,
+                    logger);
+            }
+
+            if (typeof(Google.Protobuf.IMessage).IsAssignableFrom(typeof(TValue)))
+            {
+                return new KafkaListenerProtoBuf<TKey, TValue>(executor,
+                    singleDispatch,
+                    options,
+                    brokerList,
+                    topic,
+                    consumerGroup,
+                    eventHubConnectionString,
+                    logger);
+            }
+
+            return new KafkaListener<TKey, TValue>(executor,
+                    singleDispatch,
+                    options,
+                    brokerList,
+                    topic,
+                    consumerGroup,
+                    eventHubConnectionString,
+                    logger);
+        }
+    }
+}

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerProtoBuf.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Listeners/KafkaListenerProtoBuf.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Microsoft.Azure.WebJobs.Host.Executors;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka
+{
+    /// <summary>
+    /// Kafka listener.
+    /// Connects a Kafka trigger function with a Kafka Consumer
+    /// </summary>
+    internal class KafkaListenerProtoBuf<TKey, TValue> : KafkaListener<TKey, TValue>
+    {
+        public KafkaListenerProtoBuf(
+            ITriggeredFunctionExecutor executor,
+            bool singleDispatch,
+            KafkaOptions options,
+            string brokerList,
+            string topic,
+            string consumerGroup,
+            string eventHubConnectionString,
+            ILogger logger) : base(executor, singleDispatch, options, brokerList, topic, consumerGroup, eventHubConnectionString, logger) { }
+
+        public override Task StartAsync(CancellationToken cancellationToken)
+        {
+            // protobuf: need to create using reflection due to generic requirements in ProtobufDeserializer
+            var valueDeserializer = (IDeserializer<TValue>)Activator.CreateInstance(typeof(ProtobufDeserializer<>).MakeGenericType(typeof(TValue)));
+            SetConsumerAndExecutor(null, valueDeserializer, null);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/Helpers/KafkaListenerForTest.cs
@@ -13,10 +13,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
     /// </summary>
     internal class KafkaListenerForTest<TKey, TValue> : KafkaListener<TKey, TValue>
     {
-        IConsumer<TKey, TValue> consumer;
+        private IConsumer<TKey, TValue> consumer;
 
-        public KafkaListenerForTest(ITriggeredFunctionExecutor executor, bool singleDispatch, KafkaOptions options, string brokerList, string topic, string consumerGroup, string eventHubConnectionString, string avroSchema, ILogger logger) 
-            : base(executor, singleDispatch, options, brokerList, topic, consumerGroup, eventHubConnectionString, avroSchema, logger)
+        public KafkaListenerForTest(ITriggeredFunctionExecutor executor, bool singleDispatch, KafkaOptions options, string brokerList, string topic, string consumerGroup, string eventHubConnectionString, ILogger logger)
+            : base(executor, singleDispatch, options, brokerList, topic, consumerGroup, eventHubConnectionString, logger)
         {
         }
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaListenerTest.cs
@@ -69,13 +69,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var target = new KafkaListenerForTest<Ignore, string>(
                 executor.Object,
                 singleDispatch: true,
-                new KafkaOptions(),
-                "testBroker",
-                "topic",
-                "group1",
-                null,
-                null,
-                NullLogger.Instance
+                options: new KafkaOptions(),
+                brokerList: "testBroker",
+                topic: "topic",
+                consumerGroup: "group1",
+                eventHubConnectionString: null,
+                logger: NullLogger.Instance
                 );
 
             target.SetConsumer(consumer.Object);
@@ -126,13 +125,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var target = new KafkaListenerForTest<Ignore, string>(
                 executor.Object,
                 singleDispatch: false,
-                new KafkaOptions(),
-                "testBroker",
-                "topic",
-                "group1",
-                null,
-                null,
-                NullLogger.Instance
+                options: new KafkaOptions(),
+                brokerList: "testBroker",
+                topic: "topic",
+                consumerGroup: "group1",
+                eventHubConnectionString: null,
+                logger: NullLogger.Instance
                 );
 
             target.SetConsumer(consumer.Object);
@@ -245,7 +243,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
                 "testBroker",
                 "topic",
                 "group1",
-                null,
                 null,
                 NullLogger.Instance
                 );


### PR DESCRIPTION
Resolves items 1 & 2 in #44 by doing the following:
* Creating a `KafkaListenerFactory` to be used by `KafkaTriggerAttributeBindingProvider` which serves a couple of purposes:
  1. Abstracts away knowledge of how to create specific listeners
  1. Abstracts away all the reflection gymnastics
* Creates `KafkaListenerAvro` and `KafkaListenerProtoBuf` for the Avro & Google Protocol Buffer implementations of listeners, respectively. This allows us to
* Nixes all knowledge of other listeners from `KafkaListener` and use it as a "base" implementation of a Kafka listener
* Modifies tests accordingly