### PR TITLE
Pack the nuget package and publish to the drop for release pipeline

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -3,7 +3,7 @@ variables:
   buildConfiguration: 'Release'
   Major: '0'
   Minor: '0'
-  Patch: '0-preview'
+  Patch: '0-alpha'
 
 # Enable PR validation on branches master and dev
 pr:
@@ -44,16 +44,6 @@ jobs:
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
 
-  - script: dotnet pack /p:PackageVersion=$(Major).$(Minor).$(Patch) -o '$(Build.ArtifactStagingDirectory)' --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
-    displayName: 'Pack nuget pacakge'
-  
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathToPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'drop'
-      publishLocation: 'Container'
-
-
   - task: Bash@3
     displayName: 'Start kafka in single node'
     inputs:
@@ -66,3 +56,12 @@ jobs:
     inputs:
       command: test
       projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+
+  - script: dotnet pack /p:PackageVersion=$(Major).$(Minor).$(Patch) -o '$(Build.ArtifactStagingDirectory)' --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+    displayName: 'Pack nuget pacakge'
+  
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'drop'
+      publishLocation: 'Container'

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,9 +1,7 @@
-name: $(Build.SourceBranchName)_$(Build.Reason)_$(Major).$(Minor).$(Patch).$(Build.BuildId)$(Rev:.r)
+name: $(Build.SourceBranchName)_$(Build.Reason)_$(majorVersion).$(Build.BuildId)$(Rev:.r)
 variables:
   buildConfiguration: 'Release'
-  Major: '0'
-  Minor: '0'
-  Patch: '0-alpha'
+  majorVersion: 0.0.0
 
 # Enable PR validation on branches master and dev
 pr:
@@ -57,7 +55,7 @@ jobs:
       command: test
       projects: ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
-  - script: dotnet pack /p:PackageVersion=$(Major).$(Minor).$(Patch) -o '$(Build.ArtifactStagingDirectory)' --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+  - script: dotnet pack -o '$(Build.ArtifactStagingDirectory)' --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
     displayName: 'Pack nuget pacakge'
   
   - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -1,7 +1,9 @@
-name: $(Build.SourceBranchName)_$(Build.Reason)_$(majorVersion).$(Build.BuildId)$(Rev:.r)
+name: $(Build.SourceBranchName)_$(Build.Reason)_$(Major).$(Minor).$(Patch).$(Build.BuildId)$(Rev:.r)
 variables:
   buildConfiguration: 'Release'
-  majorVersion: 0.0.0
+  Major: '0'
+  Minor: '0'
+  Patch: '0-preview'
 
 # Enable PR validation on branches master and dev
 pr:
@@ -41,6 +43,16 @@ jobs:
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Detection'
+
+  - script: dotnet pack /p:PackageVersion=$(Major).$(Minor).$(Patch) -o '$(Build.ArtifactStagingDirectory)' --include-symbols src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+    displayName: 'Pack nuget pacakge'
+  
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathToPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'drop'
+      publishLocation: 'Container'
+
 
   - task: Bash@3
     displayName: 'Start kafka in single node'

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>0.0.1$(VersionSuffix)</Version>
+    <Version>0.0.1-alpha</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
I update the build pipeline to automate the packaging nuget and start creating release pipeline for the release. 

#  What I did was: 
* build/test packaging nuget package. 
* upload to drop folder to share with release pipeline.

# Review point 
* to enable the `-preview` stuff, it looks not good. If you guys know the smart way, please let me know. 

#  Todo
* Build a Release Pipeline to publish nuget package 

For the push the package to the nuget.org, we need Azure Functions team's key for the namespace. Microsoft.Azure.WebJobs.*.  I'm talking with them about it. 
 