### PR TITLE
Add testing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,3 +305,27 @@ If you are missing an configuration setting please create an issue and describe 
 ## Quickstart
 
 For samples take a look at the [samples folder](./samples).
+
+## Testing
+
+This repo includes unit and end to end tests. End to end tests require a Kafka instance. A quick way to provide one is to use the Kafka quick start example mentioned previously or use a simpler single node docker-compose solution (also based on Confluent Docker images):
+
+Getting simple single node Kafka running:
+
+```bash
+docker-compose -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/kafka-singlenode-compose.yaml up -d
+```
+
+To shutdown the single node Kafka:
+
+```bash
+docker-compose -f ./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/kafka-singlenode-compose.yaml down
+```
+
+By default end to end tests will try to connect to Kafka on `localhost:9092`. If your Kafka broker is located in a different location create a `local.appsettings.tests.json` file in folder `./test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/` overwritting the value of LocalBroker setting like the example below:
+
+```json
+{
+    "LocalBroker": "location-of-your-kafka-broker:9092"
+}
+```

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducer.cs
@@ -134,13 +134,13 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         private void DeliveryHandler(DeliveryReport<TKey, TValue> deliveredItem)
         {
-            if (deliveredItem.Error != null)
+            if (deliveredItem.Error == null || deliveredItem.Error.Code == ErrorCode.NoError)
             {
-                this.logger.LogError("Failed to delivery message to {topic} / {partition} / {offset}. Error: {error}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset, deliveredItem.Error.ToString());
+                this.logger.LogDebug("Message delivered on {topic} / {partition} / {offset}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset);
             }
             else
             {
-                this.logger.LogDebug("Message delivered on {topic} / {partition} / {offset}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset);
+                this.logger.LogError("Failed to delivery message to {topic} / {partition} / {offset}. Error: {error}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset, deliveredItem.Error.ToString());
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Constants.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Constants.cs
@@ -3,12 +3,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 {
     internal static class Constants
     {
-        internal const string Broker = "localhost:9092";
         internal const string EndToEndTestsGroupID = "endToEndTestsGroupID";
-        internal const string StringTopicWithOnePartition = "stringTopicOnePartition";
-        internal const string StringTopicWithTenPartitions = "stringTopicTenPartitions";
-        internal const string StringTopicWithLongKeyAndTenPartitions = "stringTopicWithLongKeyTenPartitions";
-        internal const string MyAvroRecordTopic = "myAvroRecordTopic";
-        internal const string MyProtobufTopic = "myProtobufTopic";
+        internal const string StringTopicWithOnePartitionName = "stringTopicOnePartition";
+        internal const string StringTopicWithTenPartitionsName = "stringTopicTenPartitions";
+        internal const string StringTopicWithLongKeyAndTenPartitionsName = "stringTopicWithLongKeyTenPartitions";
+        internal const string MyAvroRecordTopicName = "myAvroRecordTopic";
+        internal const string MyProtobufTopicName = "myProtobufTopic";
     }
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using Confluent.Kafka.Admin;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
+{
+    /// <summary>
+    /// End to end tests fixture
+    /// </summary>
+    public class KafkaEndToEndTestFixture : IAsyncLifetime
+    {
+        internal string Broker { get; set; } = "localhost:9092";
+
+        internal string EndToEndTestsGroupID = "endToEndTestsGroupID";
+
+        internal TopicSpecification StringTopicWithOnePartition { get; } = new TopicSpecification() { Name = Constants.StringTopicWithOnePartitionName, NumPartitions = 1, ReplicationFactor = 1 };
+
+        internal TopicSpecification StringTopicWithTenPartitions { get; } = new TopicSpecification() { Name = Constants.StringTopicWithTenPartitionsName, NumPartitions = 10, ReplicationFactor = 1 };
+
+        internal TopicSpecification StringTopicWithLongKeyAndTenPartitions { get; } = new TopicSpecification() { Name = Constants.StringTopicWithLongKeyAndTenPartitionsName, NumPartitions = 10, ReplicationFactor = 1 };
+
+        internal TopicSpecification MyAvroRecordTopic { get; } = new TopicSpecification() { Name = Constants.MyAvroRecordTopicName, NumPartitions = 10, ReplicationFactor = 1 };
+
+        internal TopicSpecification MyProtobufTopic { get; } = new TopicSpecification() { Name = Constants.MyProtobufTopicName, NumPartitions = 10, ReplicationFactor = 1 };
+
+        public KafkaEndToEndTestFixture()
+        {
+            var config = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.tests.json", optional: true)
+                .AddJsonFile("appsettings.tests.local.json", optional: true)
+                .Build();
+
+            var brokerFromConfig = config["Values:LocalBroker"];
+            if (!string.IsNullOrWhiteSpace(brokerFromConfig))
+            {
+                this.Broker = brokerFromConfig;
+            }
+        }
+
+
+        /// <summary>
+        /// Helper to get all topics used in the end to end tests
+        /// </summary>
+        /// <returns>The all topics.</returns>
+        public IEnumerable<TopicSpecification> GetAllTopics()
+        {
+            foreach (var prop in this.GetType().GetProperties().Where(x => x.PropertyType == typeof(TopicSpecification)))
+            {
+                yield return (TopicSpecification)prop.GetValue(this);
+            }
+        }
+
+        public Task DisposeAsync() => Task.CompletedTask;
+
+        /// <summary>
+        /// Creates the required topics for end to end tests
+        /// </summary>
+        /// <returns>The async.</returns>
+        public async Task InitializeAsync()
+        {
+            var adminClientBuilder = new AdminClientBuilder(new AdminClientConfig()
+            {
+                BootstrapServers = this.Broker,
+
+            });
+
+            var adminClient = adminClientBuilder.Build();
+            try
+            {
+                var createTopicOptions = new CreateTopicsOptions()
+                {
+                    OperationTimeout = TimeSpan.FromMinutes(2),
+                    RequestTimeout = TimeSpan.FromMinutes(2),
+                };
+
+                await adminClient.CreateTopicsAsync(GetAllTopics(), createTopicOptions);
+            }
+            catch (KafkaException ex)
+            {
+                if (ex is CreateTopicsException createTopicsException)
+                {
+                    if (!createTopicsException.Results.All(x => x.Error.Code == ErrorCode.TopicAlreadyExists))
+                    {
+                        Console.WriteLine($"Error creation topics: {ex.ToString()}");
+                        throw;
+                    }
+                }
+                else if (!ex.Error.Reason.Equals("No topics to create", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
@@ -83,17 +83,17 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await adminClient.CreateTopicsAsync(GetAllTopics(), createTopicOptions);
             }
+            catch (CreateTopicsException createTopicsException)
+            {
+                if (!createTopicsException.Results.All(x => x.Error.Code == ErrorCode.TopicAlreadyExists))
+                {
+                    Console.WriteLine($"Error creation topics: {createTopicsException.ToString()}");
+                    throw;
+                }
+            }
             catch (KafkaException ex)
             {
-                if (ex is CreateTopicsException createTopicsException)
-                {
-                    if (!createTopicsException.Results.All(x => x.Error.Code == ErrorCode.TopicAlreadyExists))
-                    {
-                        Console.WriteLine($"Error creation topics: {ex.ToString()}");
-                        throw;
-                    }
-                }
-                else if (!ex.Error.Reason.Equals("No topics to create", StringComparison.InvariantCultureIgnoreCase))
+                if (!ex.Error.Reason.Equals("No topics to create", StringComparison.InvariantCultureIgnoreCase))
                 {
                     throw;
                 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTests.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs.Extensions.Tests;
 using Microsoft.Azure.WebJobs.Extensions.Tests.Common;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -15,9 +17,10 @@ using Xunit;
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 {
     [Trait("Category", "E2E")]
-    public class KafkaEndToEndTests
+    public class KafkaEndToEndTests : IClassFixture<KafkaEndToEndTestFixture>
     {
         private readonly TestLoggerProvider loggerProvider;
+        private readonly KafkaEndToEndTestFixture endToEndTestFixture;
 
         internal static TestLoggerProvider CreateTestLoggerProvider()
         {
@@ -26,9 +29,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 new TestLoggerProvider();
         }
 
-        public KafkaEndToEndTests()
+        public KafkaEndToEndTests(KafkaEndToEndTestFixture endToEndTestFixture)
         {
             this.loggerProvider = CreateTestLoggerProvider();
+            this.endToEndTestFixture = endToEndTestFixture;
         }
 
         [Fact]
@@ -47,11 +51,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithOnePartition,
+                    this.endToEndTestFixture.StringTopicWithOnePartition.Name,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
-
-                // await KafkaProducers.ProduceStringsAsync(Broker, StringTopicWithOnePartition, Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
-
+                    
                 await TestHelpers.Await(() =>
                 {
                     var foundCount = loggerProvider1.GetAllUserLogMessages().Count(p => p.FormattedMessage != null && p.FormattedMessage.Contains(messagePrefixBatch1));
@@ -70,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithOnePartition,
+                    this.endToEndTestFixture.StringTopicWithOnePartition.Name,
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
                     
                 await TestHelpers.Await(() =>
@@ -102,7 +104,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithOnePartition,
+                    this.endToEndTestFixture.StringTopicWithOnePartition.Name,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
                 await TestHelpers.Await(() =>
@@ -125,7 +127,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithOnePartition,
+                    this.endToEndTestFixture.StringTopicWithOnePartition.Name,
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
                 await TestHelpers.Await(() =>
@@ -157,7 +159,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithTenPartitions,
+                    this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
                 await TestHelpers.Await(() =>
@@ -180,7 +182,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithTenPartitions,
+                    this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
                 await TestHelpers.Await(() =>
@@ -212,7 +214,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithTenPartitions,
+                    this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefixBatch1 + x));
 
                 await TestHelpers.Await(() =>
@@ -235,7 +237,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                    Constants.StringTopicWithTenPartitions,
+                    this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
                     Enumerable.Range(1 + producedMessagesCount, producedMessagesCount).Select(x => messagePrefixBatch2 + x));
 
                 await TestHelpers.Await(() =>
@@ -265,7 +267,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
             var producerTask = producerJobHost.CallOutputTriggerStringAsync(
                 GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringTopic)),
-                Constants.StringTopicWithTenPartitions,
+                this.endToEndTestFixture.StringTopicWithTenPartitions.Name,
                 Enumerable.Range(1, producedMessagesCount).Select(x => EndToEndTestExtensions.CreateMessageValue(messagePrefix, x)), 
                 TimeSpan.FromMilliseconds(100));
 
@@ -373,7 +375,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringWithLongKeyAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendToStringWithLongKeyTopic)),
-                    Constants.StringTopicWithLongKeyAndTenPartitions,
+                    this.endToEndTestFixture.StringTopicWithLongKeyAndTenPartitions.Name,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefix + x),
                     Enumerable.Range(1, producedMessagesCount).Select(x => x % 20L));
                     
@@ -400,7 +402,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringWithStringKeyAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendAvroWithStringKeyTopic)),
-                    Constants.MyAvroRecordTopic,
+                    this.endToEndTestFixture.MyAvroRecordTopic.Name,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefix + x),
                     Enumerable.Range(1, producedMessagesCount).Select(x => "record_" + (x % 20).ToString())
                     );
@@ -428,7 +430,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await jobHost.CallOutputTriggerStringWithStringKeyAsync(
                     GetStaticMethod(typeof(KafkaOutputFunctions), nameof(KafkaOutputFunctions.SendProtobufWithStringKeyTopic)),
-                    Constants.MyProtobufTopic,
+                    this.endToEndTestFixture.MyProtobufTopic.Name,
                     Enumerable.Range(1, producedMessagesCount).Select(x => messagePrefix + x),
                     Enumerable.Range(1, producedMessagesCount).Select(x => "record_" + (x % 20).ToString())
                     );
@@ -458,8 +460,9 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 })
                 .ConfigureAppConfiguration(c =>
                 {
-                    //c.AddTestSettings();
-                    //c.AddJsonFile("appsettings.tests.json", optional: false);
+                    c.AddTestSettings();
+                    c.AddJsonFile("appsettings.tests.json", optional: true);
+                    c.AddJsonFile("local.appsettings.tests.json", optional: true);
                 })
                 .ConfigureServices(services =>
                 {

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaOutputFunctions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaOutputFunctions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             string topic,
             IEnumerable<string> content,
             TimeSpan? interval,
-            [Kafka(BrokerList = Constants.Broker)] IAsyncCollector<KafkaEventData> output)
+            [Kafka(BrokerList = "LocalBroker")] IAsyncCollector<KafkaEventData> output)
         {
             foreach (var c in content)
             {
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             IEnumerable<long> keys,
             IEnumerable<string> content,
             TimeSpan? interval,
-            [Kafka(BrokerList = Constants.Broker, KeyType = typeof(long))] IAsyncCollector<KafkaEventData> output)
+            [Kafka(BrokerList = "LocalBroker", KeyType = typeof(long))] IAsyncCollector<KafkaEventData> output)
         {
 
             var keysEnumerator = keys.GetEnumerator();
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             IEnumerable<string> keys,
             IEnumerable<string> content,
             TimeSpan? interval,
-            [Kafka(BrokerList = Constants.Broker, KeyType = typeof(string), ValueType = typeof(MyAvroRecord))] IAsyncCollector<KafkaEventData> output)
+            [Kafka(BrokerList = "LocalBroker", KeyType = typeof(string), ValueType = typeof(MyAvroRecord))] IAsyncCollector<KafkaEventData> output)
         {
 
             var keysEnumerator = keys.GetEnumerator();
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             IEnumerable<string> keys,
             IEnumerable<string> content,
             TimeSpan? interval,
-            [Kafka(BrokerList = Constants.Broker, KeyType = typeof(string), ValueType = typeof(ProtoUser))] IAsyncCollector<KafkaEventData> output)
+            [Kafka(BrokerList = "LocalBroker", KeyType = typeof(string), ValueType = typeof(ProtoUser))] IAsyncCollector<KafkaEventData> output)
         {
             var colors = new[] { "red", "blue", "green" };
 

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -12,6 +12,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
+    <None Update="local.appsettings.tests.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MultiItemTrigger.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MultiItemTrigger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
     internal static class MultiItemTrigger
     {
         public static void Trigger(
-            [KafkaTrigger(Constants.Broker, Constants.StringTopicWithOnePartition, ConsumerGroup = nameof(MultiItemTrigger))] KafkaEventData[] kafkaEvents,
+            [KafkaTrigger("LocalBroker", Constants.StringTopicWithOnePartitionName, ConsumerGroup = nameof(MultiItemTrigger))] KafkaEventData[] kafkaEvents,
             ILogger log)
         {
             foreach (var kafkaEvent in kafkaEvents)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MultiItemTriggerTenPartitions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MultiItemTriggerTenPartitions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
     internal static class MultiItemTriggerTenPartitions
     {
         public static void Trigger(
-            [KafkaTrigger(Constants.Broker, Constants.StringTopicWithTenPartitions, ConsumerGroup = nameof(MultiItemTriggerTenPartitions))] KafkaEventData[] kafkaEvents,
+            [KafkaTrigger("LocalBroker", Constants.StringTopicWithTenPartitionsName, ConsumerGroup = nameof(MultiItemTriggerTenPartitions))] KafkaEventData[] kafkaEvents,
             ILogger log)
         {
             foreach (var kafkaEvent in kafkaEvents)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MyProtobufTrigger.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MyProtobufTrigger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
     internal static class MyProtobufTrigger
     {
         public static void Trigger(
-            [KafkaTrigger(Constants.Broker, Constants.MyProtobufTopic, ValueType = typeof(ProtoUser), KeyType = typeof(string), ConsumerGroup = nameof(MyRecordAvroTrigger))] KafkaEventData[] kafkaEvents,
+            [KafkaTrigger("LocalBroker", Constants.MyProtobufTopicName, ValueType = typeof(ProtoUser), KeyType = typeof(string), ConsumerGroup = nameof(MyRecordAvroTrigger))] KafkaEventData[] kafkaEvents,
             ILogger log)
         {
             foreach (var kafkaEvent in kafkaEvents)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MyRecordAvroTrigger.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/MyRecordAvroTrigger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
     internal static class MyRecordAvroTrigger
     {
         public static void Trigger(
-            [KafkaTrigger(Constants.Broker, Constants.MyAvroRecordTopic, ValueType = typeof(MyAvroRecord), KeyType = typeof(string), ConsumerGroup = nameof(MyRecordAvroTrigger))] KafkaEventData[] kafkaEvents,
+            [KafkaTrigger("LocalBroker", Constants.MyAvroRecordTopicName, ValueType = typeof(MyAvroRecord), KeyType = typeof(string), ConsumerGroup = nameof(MyRecordAvroTrigger))] KafkaEventData[] kafkaEvents,
             ILogger log)
         {
             foreach (var kafkaEvent in kafkaEvents)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/SingleItemTrigger.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/SingleItemTrigger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
     internal static class SingleItemTrigger
     {
         public static void Trigger(
-            [KafkaTrigger(Constants.Broker, Constants.StringTopicWithOnePartition, ConsumerGroup = nameof(SingleItemTrigger))] KafkaEventData kafkaEvent,
+            [KafkaTrigger("LocalBroker", Constants.StringTopicWithOnePartitionName, ConsumerGroup = nameof(SingleItemTrigger))] KafkaEventData kafkaEvent,
             ILogger log)
         {
             log.LogInformation(kafkaEvent.Value.ToString());

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/SingleItemTriggerTenPartitions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/SingleItemTriggerTenPartitions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
     internal static class SingleItemTriggerTenPartitions
     {
         public static void Trigger(
-            [KafkaTrigger(Constants.Broker, Constants.StringTopicWithTenPartitions, ConsumerGroup = nameof(SingleItemTriggerTenPartitions))] KafkaEventData kafkaEvent,
+            [KafkaTrigger("LocalBroker", Constants.StringTopicWithTenPartitionsName, ConsumerGroup = nameof(SingleItemTriggerTenPartitions))] KafkaEventData kafkaEvent,
             ILogger log)
         {
             log.LogInformation(kafkaEvent.Value.ToString());

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/StringTopicWithLongKeyAndTenPartitionsTrigger.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/StringTopicWithLongKeyAndTenPartitionsTrigger.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
     internal static class StringTopicWithLongKeyAndTenPartitionsTrigger
     {
         public static void Trigger(
-            [KafkaTrigger(Constants.Broker, Constants.StringTopicWithLongKeyAndTenPartitions, ConsumerGroup = nameof(StringTopicWithLongKeyAndTenPartitionsTrigger), KeyType = typeof(long))] KafkaEventData[] kafkaEvents,
+            [KafkaTrigger("LocalBroker", Constants.StringTopicWithLongKeyAndTenPartitionsName, ConsumerGroup = nameof(StringTopicWithLongKeyAndTenPartitionsTrigger), KeyType = typeof(long))] KafkaEventData[] kafkaEvents,
             ILogger log)
         {
             foreach (var kafkaEvent in kafkaEvents)

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/appsettings.tests.json
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/appsettings.tests.json
@@ -1,8 +1,3 @@
 ﻿{
-    "IsEncrypted": false,
-    "Values": {
-        "AzureWebJobsStorage": "None",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet",
-        "LocalBroker": "localhost:9092"
-    }
+    "LocalBroker": "localhost:9092"
 }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/start-kafka-test-environment.sh
@@ -8,9 +8,3 @@ docker-compose -f ./kafka-singlenode-compose.yaml  up --build -d
 # wait until kafka is ready to create topic
 # need to improve, adding a retry instead of a static sleep
 sleep 30
-
-docker-compose -f ./kafka-singlenode-compose.yaml exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 1 --topic stringTopicOnePartition
-docker-compose -f ./kafka-singlenode-compose.yaml exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 10 --topic stringTopicTenPartitions
-docker-compose -f ./kafka-singlenode-compose.yaml exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 10 --topic stringTopicWithLongKeyTenPartitions
-docker-compose -f ./kafka-singlenode-compose.yaml exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 10 --topic myAvroRecordTopic
-docker-compose -f ./kafka-singlenode-compose.yaml exec kafka kafka-topics --create --zookeeper zookeeper:2181 --replication-factor 1 --partitions 10 --topic myProtobufTopic


### PR DESCRIPTION
Changes:
* Fix logging of failed produced messages
* Add testing documentation
* Moved partition creation to test fixture to simplify running end to end tests locally
* Add support to run end to end tests against a Kafka broker located in a different place than localhost:9092

Fixes #46 
Part of #31 