### PR TITLE
Fix e2e bug introduced by batch message output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,4 @@ __pycache__/
 !.vscode/extensions.json
 
 local.settings.json
+local.appsettings.tests.json

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/EndToEndTestExtensions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/EndToEndTestExtensions.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         /// <summary>
         /// Calls the output trigger string
         /// </summary>
-        public static async Task CallOutputTriggerStringAsync(this JobHost jobHost, MethodInfo method, string topic, IEnumerable<object> values, TimeSpan? interval = null)
+        public static async Task CallOutputTriggerStringAsync(this JobHost jobHost, MethodInfo method, string topic, IEnumerable<object> values)
         {
             var allValues = values.Select(x => x.ToString());
-            await jobHost.CallAsync(method, new { topic = topic, content = allValues, interval = interval });
+            await jobHost.CallAsync(method, new { topic = topic, content = allValues });
         }
 
         /// <summary>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaEndToEndTestFixture.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.Kafka.Admin;
@@ -52,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         /// <returns>The all topics.</returns>
         public IEnumerable<TopicSpecification> GetAllTopics()
         {
-            foreach (var prop in this.GetType().GetProperties().Where(x => x.PropertyType == typeof(TopicSpecification)))
+            foreach (var prop in this.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Instance).Where(x => x.PropertyType == typeof(TopicSpecification)))
             {
                 yield return (TopicSpecification)prop.GetValue(this);
             }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaOutputFunctions.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/KafkaOutputFunctions.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
         public static async Task SendToStringTopic(
             string topic,
             IEnumerable<string> content,
-            TimeSpan? interval,
             [Kafka(BrokerList = "LocalBroker")] IAsyncCollector<KafkaEventData> output)
         {
             foreach (var c in content)
@@ -24,12 +23,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 };
 
                 await output.AddAsync(message);
-
-                if (interval.HasValue)
-                {
-                    await Task.Delay(interval.Value);
-
-                }
             }
         }
 
@@ -37,7 +30,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             string topic,
             IEnumerable<long> keys,
             IEnumerable<string> content,
-            TimeSpan? interval,
             [Kafka(BrokerList = "LocalBroker", KeyType = typeof(long))] IAsyncCollector<KafkaEventData> output)
         {
 
@@ -53,12 +45,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 };
 
                 await output.AddAsync(message);
-
-                if (interval.HasValue)
-                {
-                    await Task.Delay(interval.Value);
-
-                }
             }
         }
 
@@ -66,7 +52,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             string topic,
             IEnumerable<string> keys,
             IEnumerable<string> content,
-            TimeSpan? interval,
             [Kafka(BrokerList = "LocalBroker", KeyType = typeof(string), ValueType = typeof(MyAvroRecord))] IAsyncCollector<KafkaEventData> output)
         {
 
@@ -87,11 +72,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
                 };
 
                 await output.AddAsync(message);
-
-                if (interval.HasValue)
-                {
-                    await Task.Delay(interval.Value);
-                }
             }
         }
 
@@ -99,7 +79,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
             string topic,
             IEnumerable<string> keys,
             IEnumerable<string> content,
-            TimeSpan? interval,
             [Kafka(BrokerList = "LocalBroker", KeyType = typeof(string), ValueType = typeof(ProtoUser))] IAsyncCollector<KafkaEventData> output)
         {
             var colors = new[] { "red", "blue", "green" };
@@ -124,11 +103,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests
 
                 await output.AddAsync(message);
                 i++;
-
-                if (interval.HasValue)
-                {
-                    await Task.Delay(interval.Value);
-                }
             }
         }
     }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Update="local.appsettings.tests.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
     <None Update="appsettings.tests.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>


### PR DESCRIPTION
Changes

* Fixes the topic creation in e2e text fixture. There was a problem getting the properties and topic with 1 partition was being automatically created
* Fixes timing issue in e2e caused by output binder send events only when flushed 