### PR TITLE
Add properties for producer configuration to Output Binding Attribute definition

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// <param name="topic">Topic name</param>
         public KafkaAttribute(string topic)
         {
-            Topic = topic;
+            this.Topic = topic;
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         public Type KeyType { get; set; }
 
-        Type valueType;
+        private Type valueType;
 
         /// <summary>
         /// Gets or sets the Avro data type
@@ -57,15 +57,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         public Type ValueType
         {
-            get => this.valueType;
+            get => valueType;
             set
             {
                 if (value != null && !IsValidValueType(value))
                 {
-                    throw new ArgumentException($"The value of {nameof(ValueType)} must be a byte[], string or a type that implements {nameof(ISpecificRecord)} or {nameof(Google.Protobuf.IMessage)}. The type {value.Name} does not.");
+                    throw new ArgumentException($"The value of {nameof(this.ValueType)} must be a byte[], string or a type that implements {nameof(ISpecificRecord)} or {nameof(Google.Protobuf.IMessage)}. The type {value.Name} does not.");
                 }
 
-                this.valueType = value;
+                valueType = value;
             }
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         public string AvroSchema { get; set; }
 
-        bool IsValidValueType(Type value)
+        private bool IsValidValueType(Type value)
         {
             return
                 typeof(ISpecificRecord).IsAssignableFrom(value) ||
@@ -83,5 +83,36 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 value == typeof(byte[]) ||
                 value == typeof(string);
         }
+
+        /// <summary>
+        /// Gets or sets the Maximum transmit message size. Default: 1MB
+        /// </summary>
+        public int MaxMessageBytes { get; set; } = 1024000;
+
+        /// <summary>
+        /// Maximum number of messages batched in one MessageSet. default: 10000
+        /// </summary>
+        public int BatchSize { get; set; } = 1000;
+
+        /// <summary>
+        /// When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. default: false
+        /// </summary>
+        public bool EnableIdempotence { get; set; } = false;
+
+        /// <summary>
+        /// Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time used to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded. default: 300000
+        /// </summary>
+        public int MessageTimeoutMs { get; set; } = 300000;
+
+        /// <summary>
+        /// The ack timeout of the producer request in milliseconds. default: 5000
+        /// </summary>
+        public int RequestTimeoutMs { get; set; } = 5000;
+
+        /// <summary>
+        /// How many times to retry sending a failing Message. **Note:** default: 2 
+        /// </summary>
+        /// <remarks>Retrying may cause reordering unless <c>EnableIdempotence</c> is set to <c>true</c>.</remarks>
+        public int MaxRetries { get; set; } = 2;
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -87,32 +87,32 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// <summary>
         /// Gets or sets the Maximum transmit message size. Default: 1MB
         /// </summary>
-        public int MaxMessageBytes { get; set; } = 1024000;
+        public int? MaxMessageBytes { get; set; }
 
         /// <summary>
         /// Maximum number of messages batched in one MessageSet. default: 10000
         /// </summary>
-        public int BatchSize { get; set; } = 1000;
+        public int? BatchSize { get; set; }
 
         /// <summary>
         /// When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. default: false
         /// </summary>
-        public bool EnableIdempotence { get; set; } = false;
+        public bool? EnableIdempotence { get; set; }
 
         /// <summary>
         /// Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite. This is the maximum time used to deliver a message (including retries). Delivery error occurs when either the retry count or the message timeout are exceeded. default: 300000
         /// </summary>
-        public int MessageTimeoutMs { get; set; } = 300000;
+        public int? MessageTimeoutMs { get; set; }
 
         /// <summary>
         /// The ack timeout of the producer request in milliseconds. default: 5000
         /// </summary>
-        public int RequestTimeoutMs { get; set; } = 5000;
+        public int? RequestTimeoutMs { get; set; }
 
         /// <summary>
         /// How many times to retry sending a failing Message. **Note:** default: 2 
         /// </summary>
         /// <remarks>Retrying may cause reordering unless <c>EnableIdempotence</c> is set to <c>true</c>.</remarks>
-        public int MaxRetries { get; set; } = 2;
+        public int? MaxRetries { get; set; }
     }
 }

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAttribute.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// <param name="topic">Topic name</param>
         public KafkaAttribute(string topic)
         {
-            this.Topic = topic;
+            Topic = topic;
         }
 
         /// <summary>
@@ -57,15 +57,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         /// </summary>
         public Type ValueType
         {
-            get => valueType;
+            get => this.valueType;
             set
             {
                 if (value != null && !IsValidValueType(value))
                 {
-                    throw new ArgumentException($"The value of {nameof(this.ValueType)} must be a byte[], string or a type that implements {nameof(ISpecificRecord)} or {nameof(Google.Protobuf.IMessage)}. The type {value.Name} does not.");
+                    throw new ArgumentException($"The value of {nameof(ValueType)} must be a byte[], string or a type that implements {nameof(ISpecificRecord)} or {nameof(Google.Protobuf.IMessage)}. The type {value.Name} does not.");
                 }
 
-                valueType = value;
+                this.valueType = value;
             }
         }
 

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducer.cs
@@ -57,14 +57,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 builder.SetKeySerializer(keySerializer);
             }
 
-            producer = builder.Build();
+            this.producer = builder.Build();
         }
 
         public void Flush(CancellationToken cancellationToken)
         {
             try
             {
-                producer.Flush(cancellationToken);
+                this.producer.Flush(cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error flushing Kafka producer");
+                this.logger.LogError(ex, "Error flushing Kafka producer");
                 throw;
             }
         }
@@ -122,11 +122,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             try
             {
-                producer.BeginProduce(topicUsed, msg, DeliveryHandler);
+                this.producer.BeginProduce(topicUsed, msg, this.DeliveryHandler);
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error producing into {topic}", topicUsed);
+                this.logger.LogError(ex, "Error producing into {topic}", topicUsed);
                 throw;
             }
         }
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             if (deliveredItem.Error == null || deliveredItem.Error.Code == ErrorCode.NoError)
             {
-                logger.LogDebug("Message delivered on {topic} / {partition} / {offset}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset);
+                this.logger.LogDebug("Message delivered on {topic} / {partition} / {offset}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset);
             }
             else
             {

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducer.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaProducer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
 using Confluent.Kafka;
 using Confluent.SchemaRegistry.Serdes;
 using Microsoft.Extensions.Logging;
@@ -58,14 +57,14 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
                 builder.SetKeySerializer(keySerializer);
             }
 
-            this.producer = builder.Build();
+            producer = builder.Build();
         }
 
         public void Flush(CancellationToken cancellationToken)
         {
             try
             {
-                this.producer.Flush(cancellationToken);
+                producer.Flush(cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -73,7 +72,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
             }
             catch (Exception ex)
             {
-                this.logger.LogError(ex, "Error flushing Kafka producer");
+                logger.LogError(ex, "Error flushing Kafka producer");
                 throw;
             }
         }
@@ -123,11 +122,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
             try
             {
-                this.producer.BeginProduce(topicUsed, msg, this.DeliveryHandler);
+                producer.BeginProduce(topicUsed, msg, DeliveryHandler);
             }
             catch (Exception ex)
             {
-                this.logger.LogError(ex, "Error producing into {topic}", topicUsed);
+                logger.LogError(ex, "Error producing into {topic}", topicUsed);
                 throw;
             }
         }
@@ -136,11 +135,11 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
         {
             if (deliveredItem.Error == null || deliveredItem.Error.Code == ErrorCode.NoError)
             {
-                this.logger.LogDebug("Message delivered on {topic} / {partition} / {offset}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset);
+                logger.LogDebug("Message delivered on {topic} / {partition} / {offset}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset);
             }
             else
             {
-                this.logger.LogError("Failed to delivery message to {topic} / {partition} / {offset}. Error: {error}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset, deliveredItem.Error.ToString());
+                logger.LogError("Failed to delivery message to {topic} / {partition} / {offset}. Reason: {reason}. Full Error: {error}", deliveredItem.Topic, (int)deliveredItem.Partition, (long)deliveredItem.Offset, deliveredItem.Error.Reason, deliveredItem.Error.ToString());
             }
         }
     }


### PR DESCRIPTION
Targeting #11 

Would appreciate review of this; since we're just piping them down in to the Kafka `ProducerConfig` object, I'm not sure there's any additional work needed.