### PR TITLE
KafkaAsyncCollector doesn't require topic in ctor

### DIFF
--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAsyncCollector.cs
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Output/KafkaAsyncCollector.cs
@@ -15,11 +15,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka
 
         public KafkaAsyncCollector(string topic, IKafkaProducer producer)
         {
-            if (topic == null)
-            {
-                throw new ArgumentNullException(nameof(topic));
-            }
-
             if (producer == null)
             {
                 throw new ArgumentNullException(nameof(producer));

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaAsyncCollectorTests.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaAsyncCollectorTests.cs
@@ -12,13 +12,6 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
     public class KafkaAsyncCollectorTests
     {
         [Fact]
-        public void Topic_NullArgumentCheck()
-        {
-            var mockProducer = new Mock<IKafkaProducer>();
-            Assert.Throws<ArgumentNullException>(() => new KafkaAsyncCollector(null, mockProducer.Object));
-        }
-
-        [Fact]
         public void Producer_NullArgumentCheck()
         {
             var mockProducer = new Mock<IKafkaProducer>();


### PR DESCRIPTION
The destination Kafka topic can be decided during the function execution (`KafkaEventData.Topic = "foo";`). Therefore I am removing the argument null check at the constructor and associated test.

CI should pass again.