### PR TITLE
Add trigger binding to offset, timestamp as params

### DIFF
--- a/samples/dotnet/KafkaFunctionSample/AvroGenericTriggers.cs
+++ b/samples/dotnet/KafkaFunctionSample/AvroGenericTriggers.cs
@@ -43,13 +43,18 @@ namespace KafkaFunctionSample
         [FunctionName(nameof(PageViews))]
         public static void PageViews(
            [KafkaTrigger("LocalBroker", "pageviews", AvroSchema = PageViewsSchema, ConsumerGroup = "azfunc")] KafkaEventData[] kafkaEvents,
+           long[] offsetArray,
+           int[] partitionArray,
+           string[] topicArray,
+           DateTime[] timestampArray,
            ILogger logger)
         {
-            foreach (var kafkaEvent in kafkaEvents)
+            for (int i = 0; i < kafkaEvents.Length; i++)
             {
+                var kafkaEvent = kafkaEvents[i];
                 if (kafkaEvent.Value is GenericRecord genericRecord)
                 {
-                    logger.LogInformation($"{GenericToJson(genericRecord)}");
+                    logger.LogInformation($"[{timestampArray[i]}] {topicArray[i]} / {partitionArray[i]} / {offsetArray[i]}: {GenericToJson(genericRecord)}");
                 }
             }
         }

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerBindingStrategyTest.cs
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests/KafkaTriggerBindingStrategyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
@@ -14,11 +15,12 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var strategy = new KafkaTriggerBindingStrategy();
             var contract = strategy.GetBindingContract();
 
-            Assert.Equal(4, contract.Count);
+            Assert.Equal(5, contract.Count);
             Assert.Equal(typeof(object), contract["Key"]);
             Assert.Equal(typeof(int), contract["Partition"]);
             Assert.Equal(typeof(string), contract["Topic"]);
             Assert.Equal(typeof(DateTime), contract["Timestamp"]);
+            Assert.Equal(typeof(long), contract["Offset"]);
         }
 
         [Fact]
@@ -27,11 +29,82 @@ namespace Microsoft.Azure.WebJobs.Extensions.Kafka.UnitTests
             var strategy = new KafkaTriggerBindingStrategy();
             var contract = strategy.GetBindingContract(true);
 
-            Assert.Equal(4, contract.Count);
+            Assert.Equal(5, contract.Count);
             Assert.Equal(typeof(object), contract["Key"]);
             Assert.Equal(typeof(int), contract["Partition"]);
             Assert.Equal(typeof(string), contract["Topic"]);
             Assert.Equal(typeof(DateTime), contract["Timestamp"]);
+            Assert.Equal(typeof(long), contract["Offset"]);
+        }
+
+        [Fact]
+        public void SingleDispatch_GetBindingData_Should_Create_Data_From_Kafka_Event()
+        {
+            var kafkaEventData = new KafkaEventData()
+            {
+                Key = "1",
+                Offset = 100,
+                Partition = 2,
+                Timestamp = new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc),
+                Topic = "myTopic",
+                Value = "Nothing",
+            };
+
+            var strategy = new KafkaTriggerBindingStrategy();
+            var binding = strategy.GetBindingData(KafkaTriggerInput.New(kafkaEventData));
+            Assert.Equal("1", binding["Key"]);
+            Assert.Equal(100L, binding["Offset"]);
+            Assert.Equal(2, binding["Partition"]);
+            Assert.Equal(new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), binding["Timestamp"]);
+            Assert.Equal("myTopic", binding["Topic"]);
+
+            // lower case too
+            Assert.Equal("1", binding["key"]);
+            Assert.Equal(100L, binding["offset"]);
+            Assert.Equal(2, binding["partition"]);
+            Assert.Equal(new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), binding["timestamp"]);
+            Assert.Equal("myTopic", binding["topic"]);
+        }
+
+        [Fact]
+        public void MultiDispatch_GetBindingData_Should_Create_Data_From_Kafka_Event()
+        {
+            var triggerInput = KafkaTriggerInput.New(new[]
+            {
+                new KafkaEventData()
+                {
+                    Key = "1",
+                    Offset = 100,
+                    Partition = 2,
+                    Timestamp = new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc),
+                    Topic = "myTopic",
+                    Value = "Nothing1",
+                },
+                new KafkaEventData()
+                {
+                    Key = "2",
+                    Offset = 101,
+                    Partition = 2,
+                    Timestamp = new DateTime(2019, 1, 10, 9, 21, 1, DateTimeKind.Utc),
+                    Topic = "myTopic",
+                    Value = "Nothing2",
+                },
+            });
+
+            var strategy = new KafkaTriggerBindingStrategy();
+            var binding = strategy.GetBindingData(triggerInput);
+            Assert.Equal(new[] { "1", "2" }, binding["KeyArray"]);
+            Assert.Equal(new[] { 100L, 101L }, binding["OffsetArray"]);
+            Assert.Equal(new[] { 2, 2 }, binding["PartitionArray"]);
+            Assert.Equal(new[] { new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), new DateTime(2019, 1, 10, 9, 21, 1, DateTimeKind.Utc) }, binding["TimestampArray"]);
+            Assert.Equal(new[] { "myTopic", "myTopic" }, binding["TopicArray"]);
+
+            // lower case too
+            Assert.Equal(new[] { "1", "2" }, binding["keyArray"]);
+            Assert.Equal(new[] { 100L, 101L }, binding["offsetArray"]);
+            Assert.Equal(new[] { 2, 2 }, binding["partitionArray"]);
+            Assert.Equal(new[] { new DateTime(2019, 1, 10, 9, 21, 0, DateTimeKind.Utc), new DateTime(2019, 1, 10, 9, 21, 1, DateTimeKind.Utc) }, binding["timestampArray"]);
+            Assert.Equal(new[] { "myTopic", "myTopic" }, binding["topicArray"]);
         }
     }
 }


### PR DESCRIPTION
**Changes**

* Polishes the automatic binding of `topic, partition, offset, timestamp and key` in trigger functions
* Sample function modified to illustrate how to use automatic binding

 Sample:

```csharp
[FunctionName(nameof(PageViews))]
public static void PageViews(
    [KafkaTrigger("LocalBroker", "pageviews", AvroSchema = PageViewsSchema, ConsumerGroup = "azfunc")] KafkaEventData[] kafkaEvents,
    long[] offsetArray,
    int[] partitionArray,
    string[] topicArray,
    DateTime[] timestampArray)
{
    // offsetArray will contain the offsets of each message
    // same for partitionArray, topicArray and timestampArray
}
```


Part of #44 