### PR TITLE
Version Suffix for CI

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>0.0.1-alpha</Version>
+    <Version>0.0.1-alpha$(VersionSuffix)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>0.0.1-alpha$(VersionSuffix)</Version>
+    <Version>0.0.1$(VersionSuffix)-alpha</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <!-- Extensions can have independent versions and only increment when released -->
-    <Version>0.0.1$(VersionSuffix)-alpha</Version>
+    <Version>0.0.1-alpha$(VersionSuffix)</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
Sorry, I want to get back the Version Suffix according to the Brandon advice. 
Now I know how to use it.  It is ignored for the CI pipeline if you don't specify the Version Suffix. 
However, under the development, you might use nuget package for testing.  In this case, 
you can set the Version Suffix then, it will be '0-0-0-alpha71'  71 is build id.  

It is automatically create/publish nuget package to private nuget repo. 

If you can see the pipeline example, it is on the our project Azure DevOps, Publish-Nuget-To-Private.CI. Once this PR gets merged, the pipeline can be available for the member of developer. 

Regards, 
Tsuyoshi 