### PR TITLE
Update to Confluent.Kafka RC3

### DIFF
--- a/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
+++ b/samples/dotnet/ConsoleConsumer/ConsoleConsumer.csproj
@@ -5,8 +5,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
   </ItemGroup>
    <ItemGroup>
     <None Update="cacert.pem">

--- a/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
+++ b/samples/dotnet/ConsoleProducer/ConsoleProducer.csproj
@@ -6,8 +6,8 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>
    <ItemGroup>

--- a/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
+++ b/samples/dotnet/KafkaFunctionSample/KafkaFunctionSample.csproj
@@ -5,7 +5,7 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
   </ItemGroup>

--- a/samples/dotnet/SampleHost/SampleHost.csproj
+++ b/samples/dotnet/SampleHost/SampleHost.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />

--- a/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
+++ b/src/Microsoft.Azure.WebJobs.Extensions.Kafka/Microsoft.Azure.WebJobs.Extensions.Kafka.csproj
@@ -21,9 +21,9 @@
     <WarningsAsErrors />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta004">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
+++ b/test/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests/Microsoft.Azure.WebJobs.Extensions.Kafka.EndToEndTests.csproj
@@ -27,8 +27,8 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging" Version="3.0.5" />
-    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC2" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC2" />
+    <PackageReference Include="Confluent.Kafka" Version="1.0.0-RC3" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.0.0-RC3" />
     <PackageReference Include="Google.Protobuf" Version="3.7.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.4" />
   </ItemGroup>


### PR DESCRIPTION
As Confluent.Kafka gets ready to release 1.0 I want to keep us close as possible to the release bits in order to identify potential problems as early as possible.

This PR updates the dependencies to what seems to be the last RC before 1.0 release.

Fixes #62 